### PR TITLE
fix: replace date io with mui functions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
-        "@date-io/core": "^3.2.0",
-        "@date-io/date-fns": "^3.2.1",
         "@emotion/core": "^11.0.0",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
@@ -2491,29 +2489,6 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
-      }
-    },
-    "node_modules/@date-io/core": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@date-io/core/-/core-3.2.0.tgz",
-      "integrity": "sha512-hqwXvY8/YBsT9RwQITG868ZNb1MVFFkF7W1Ecv4P472j/ZWa7EFcgSmxy8PUElNVZfvhdvfv+a8j6NWJqOX5mA==",
-      "license": "MIT"
-    },
-    "node_modules/@date-io/date-fns": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@date-io/date-fns/-/date-fns-3.2.1.tgz",
-      "integrity": "sha512-CtXgTOAamkImI+CmbWRNdBi4ljj9xm/tdoPa+eeeiygduzubJTsXp18vYz+Vs/9yLho1zUOXlxpsfsF7PsXSWQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@date-io/core": "^3.2.0"
-      },
-      "peerDependencies": {
-        "date-fns": "^3.2.0 || ^4.1.0"
-      },
-      "peerDependenciesMeta": {
-        "date-fns": {
-          "optional": true
-        }
       }
     },
     "node_modules/@discoveryjs/json-ext": {

--- a/package.json
+++ b/package.json
@@ -111,8 +111,6 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.28.4",
-    "@date-io/core": "^3.2.0",
-    "@date-io/date-fns": "^3.2.1",
     "@emotion/core": "^11.0.0",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",

--- a/src/components/MTableEditField/BooleanField.js
+++ b/src/components/MTableEditField/BooleanField.js
@@ -28,6 +28,11 @@ function BooleanField({ forwardedRef, ...props }) {
                 width: 24,
                 marginLeft: 9
               }}
+              slotProps={{
+                input: {
+                  'aria-label': props.columnDef.title
+                }
+              }}
             />
           }
         />

--- a/src/components/MTableEditField/BooleanField.js
+++ b/src/components/MTableEditField/BooleanField.js
@@ -28,9 +28,6 @@ function BooleanField({ forwardedRef, ...props }) {
                 width: 24,
                 marginLeft: 9
               }}
-              inputProps={{
-                'aria-label': props.columnDef.title
-              }}
             />
           }
         />

--- a/src/components/MTableEditField/CurrencyField.js
+++ b/src/components/MTableEditField/CurrencyField.js
@@ -16,15 +16,17 @@ function CurrencyField({ forwardedRef, ...props }) {
         }
         return props.onChange(value);
       }}
-      InputProps={{
-        style: {
-          fontSize: 13,
-          textAlign: 'right'
+      slotProps={{
+        input: {
+          style: {
+            fontSize: 13,
+            textAlign: 'right'
+          }
+        },
+        htmlInput: {
+          'aria-label': props.columnDef.title,
+          style: { textAlign: 'right' }
         }
-      }}
-      inputProps={{
-        'aria-label': props.columnDef.title,
-        style: { textAlign: 'right' }
       }}
       onKeyDown={props.onKeyDown}
       autoFocus={props.autoFocus}

--- a/src/components/MTableEditField/DateField.js
+++ b/src/components/MTableEditField/DateField.js
@@ -39,7 +39,7 @@ function DateField({
         format={dateFormat}
         value={value || null}
         onChange={onChange}
-        clearable
+        slotProps={{ actionBar: { actions: ['clear'] } }}
         InputProps={{
           style: {
             fontSize: 13

--- a/src/components/MTableEditField/DateField.js
+++ b/src/components/MTableEditField/DateField.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFnsV3';
+import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import { TextField } from '@mui/material';
 import { LocalizationProvider, DatePicker } from '@mui/x-date-pickers';
 

--- a/src/components/MTableEditField/DateField.js
+++ b/src/components/MTableEditField/DateField.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
-import { TextField } from '@mui/material';
 import { LocalizationProvider, DatePicker } from '@mui/x-date-pickers';
 
 function DateField({
@@ -39,15 +38,16 @@ function DateField({
         format={dateFormat}
         value={value || null}
         onChange={onChange}
-        slotProps={{ actionBar: { actions: ['clear'] } }}
-        InputProps={{
-          style: {
-            fontSize: 13
+        slotProps={{
+          actionBar: { actions: ['clear'] },
+          textField: {
+            InputProps: {
+              style: { fontSize: 13 }
+            },
+            inputProps: {
+              'aria-label': `${props.columnDef.title}: press space to edit`,
+            }
           }
-        }}
-        renderInput={(params) => <TextField {...params} />}
-        inputProps={{
-          'aria-label': `${columnDef.title}: press space to edit`
         }}
       />
     </LocalizationProvider>

--- a/src/components/MTableEditField/DateField.js
+++ b/src/components/MTableEditField/DateField.js
@@ -45,7 +45,7 @@ function DateField({
               style: { fontSize: 13 }
             },
             inputProps: {
-              'aria-label': `${props.columnDef.title}: press space to edit`,
+              'aria-label': `${columnDef.title}: press space to edit`,
             }
           }
         }}

--- a/src/components/MTableEditField/DateTimeField.js
+++ b/src/components/MTableEditField/DateTimeField.js
@@ -12,7 +12,7 @@ function DateTimeField({ forwardedRef, ...props }) {
         format="dd.MM.yyyy HH:mm:ss"
         value={props.value || null}
         onChange={props.onChange}
-        clearable
+        slotProps={{ actionBar: { actions: ['clear'] } }}
         renderInput={(params) => <TextField {...params} />}
         InputProps={{
           style: {

--- a/src/components/MTableEditField/DateTimeField.js
+++ b/src/components/MTableEditField/DateTimeField.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import { LocalizationProvider, DateTimePicker } from '@mui/x-date-pickers';
-import TextField from '@mui/material/TextField';
 
 function DateTimeField({ forwardedRef, ...props }) {
   return (
@@ -12,15 +11,18 @@ function DateTimeField({ forwardedRef, ...props }) {
         format="dd.MM.yyyy HH:mm:ss"
         value={props.value || null}
         onChange={props.onChange}
-        slotProps={{ actionBar: { actions: ['clear'] } }}
-        renderInput={(params) => <TextField {...params} />}
-        InputProps={{
-          style: {
-            fontSize: 13
+        slotProps={{
+          textField: {
+            InputProps: {
+              style: { fontSize: 13 }
+            },
+            inputProps: {
+              'aria-label': `${props.columnDef.title}: press space to edit`,
+            }
+          },
+          actionBar: {
+            actions: ['clear']
           }
-        }}
-        inputProps={{
-          'aria-label': `${props.columnDef.title}: press space to edit`
         }}
       />
     </LocalizationProvider>

--- a/src/components/MTableEditField/DateTimeField.js
+++ b/src/components/MTableEditField/DateTimeField.js
@@ -1,17 +1,19 @@
 import React from 'react';
-import DateFnsUtils from '@date-io/date-fns';
+import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import { LocalizationProvider, DateTimePicker } from '@mui/x-date-pickers';
+import TextField from '@mui/material/TextField';
 
 function DateTimeField({ forwardedRef, ...props }) {
   return (
-    <LocalizationProvider dateAdapter={DateFnsUtils} locale={props.locale}>
+    <LocalizationProvider dateAdapter={AdapterDateFns} locale={props.locale}>
       <DateTimePicker
         {...props}
         ref={forwardedRef}
         format="dd.MM.yyyy HH:mm:ss"
         value={props.value || null}
         onChange={props.onChange}
-        clearable
+        clearable={{ clearable: true }}
+        renderInput={(params) => <TextField {...params} />}
         InputProps={{
           style: {
             fontSize: 13

--- a/src/components/MTableEditField/DateTimeField.js
+++ b/src/components/MTableEditField/DateTimeField.js
@@ -12,7 +12,7 @@ function DateTimeField({ forwardedRef, ...props }) {
         format="dd.MM.yyyy HH:mm:ss"
         value={props.value || null}
         onChange={props.onChange}
-        clearable={{ clearable: true }}
+        clearable
         renderInput={(params) => <TextField {...params} />}
         InputProps={{
           style: {

--- a/src/components/MTableEditField/TextField.js
+++ b/src/components/MTableEditField/TextField.js
@@ -17,15 +17,17 @@ function MTextField({ forwardedRef, ...props }) {
             : event.target.value
         )
       }
-      InputProps={{
-        style: {
-          minWidth: 50,
-          fontSize: 13
+      slotProps={{
+        input: {
+          style: {
+            minWidth: 50,
+            fontSize: 13
+          }
+        },
+        htmlInput: {
+          'aria-label': props.columnDef.title,
+          style: props.columnDef.type === 'numeric' ? { textAlign: 'right' } : {}
         }
-      }}
-      inputProps={{
-        'aria-label': props.columnDef.title,
-        style: props.columnDef.type === 'numeric' ? { textAlign: 'right' } : {}
       }}
     />
   );

--- a/src/components/MTableEditField/TimeField.js
+++ b/src/components/MTableEditField/TimeField.js
@@ -1,17 +1,19 @@
 import React from 'react';
-import DateFnsUtils from '@date-io/date-fns';
+import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import { LocalizationProvider, TimePicker } from '@mui/x-date-pickers';
+import TextField from '@mui/material/TextField';
 
 function TimeField({ forwardedRef, ...props }) {
   return (
-    <LocalizationProvider dateAdapter={DateFnsUtils} locale={props.locale}>
+    <LocalizationProvider dateAdapter={AdapterDateFns} locale={props.locale}>
       <TimePicker
         {...props}
         ref={forwardedRef}
         format="HH:mm:ss"
         value={props.value || null}
         onChange={props.onChange}
-        clearable
+        clearable={{ clearable: true }}
+        renderInput={(params) => <TextField {...params} />}
         InputProps={{
           style: {
             fontSize: 13

--- a/src/components/MTableEditField/TimeField.js
+++ b/src/components/MTableEditField/TimeField.js
@@ -12,7 +12,7 @@ function TimeField({ forwardedRef, ...props }) {
         format="HH:mm:ss"
         value={props.value || null}
         onChange={props.onChange}
-        clearable={{ clearable: true }}
+        clearable
         renderInput={(params) => <TextField {...params} />}
         InputProps={{
           style: {

--- a/src/components/MTableEditField/TimeField.js
+++ b/src/components/MTableEditField/TimeField.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import { LocalizationProvider, TimePicker } from '@mui/x-date-pickers';
-import TextField from '@mui/material/TextField';
 
 function TimeField({ forwardedRef, ...props }) {
   return (
@@ -12,15 +11,18 @@ function TimeField({ forwardedRef, ...props }) {
         format="HH:mm:ss"
         value={props.value || null}
         onChange={props.onChange}
-        slotProps={{ actionBar: { actions: ['clear'] } }}
-        renderInput={(params) => <TextField {...params} />}
-        InputProps={{
-          style: {
-            fontSize: 13
+        slotProps={{
+          textField: {
+            InputProps: {
+              style: { fontSize: 13 }
+            },
+            inputProps: {
+              'aria-label': `${props.columnDef.title}: press space to edit`,
+            }
+          },
+          actionBar: {
+            actions: ['clear']
           }
-        }}
-        inputProps={{
-          'aria-label': `${props.columnDef.title}: press space to edit`
         }}
       />
     </LocalizationProvider>

--- a/src/components/MTableEditField/TimeField.js
+++ b/src/components/MTableEditField/TimeField.js
@@ -12,7 +12,7 @@ function TimeField({ forwardedRef, ...props }) {
         format="HH:mm:ss"
         value={props.value || null}
         onChange={props.onChange}
-        clearable
+        slotProps={{ actionBar: { actions: ['clear'] } }}
         renderInput={(params) => <TextField {...params} />}
         InputProps={{
           style: {

--- a/src/components/MTableFilterRow/DateFilter.js
+++ b/src/components/MTableFilterRow/DateFilter.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFnsV3';
+import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import TextField from '@mui/material/TextField';
 import { getLocalizedFilterPlaceHolder } from './utils';
 import {

--- a/src/components/MTableFilterRow/DateFilter.js
+++ b/src/components/MTableFilterRow/DateFilter.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
-import TextField from '@mui/material/TextField';
 import { getLocalizedFilterPlaceHolder } from './utils';
 import {
   DatePicker,
@@ -30,7 +29,6 @@ function DateFilter({
       <DatePicker
         {...pickerProps}
         ref={forwardedRef}
-        renderInput={(params) => <TextField {...params} />}
       />
     );
   } else if (columnDef.type === 'datetime') {
@@ -38,7 +36,6 @@ function DateFilter({
       <DateTimePicker
         {...pickerProps}
         ref={forwardedRef}
-        renderInput={(params) => <TextField {...params} />}
       />
     );
   } else if (columnDef.type === 'time') {
@@ -46,7 +43,6 @@ function DateFilter({
       <TimePicker
         {...pickerProps}
         ref={forwardedRef}
-        renderInput={(params) => <TextField {...params} />}
       />
     );
   }

--- a/src/components/MTableFilterRow/DateFilter.js
+++ b/src/components/MTableFilterRow/DateFilter.js
@@ -22,7 +22,7 @@ function DateFilter({
     value: columnDef.tableData.filterValue || null,
     onChange: onDateInputChange,
     placeholder: getLocalizedFilterPlaceHolder(columnDef, localization),
-    clearable: true
+    slotProps: { actionBar: { actions: ['clear'] } }
   };
   let dateInputElement = null;
   if (columnDef.type === 'date') {

--- a/src/components/MTableFilterRow/DefaultFilter.js
+++ b/src/components/MTableFilterRow/DefaultFilter.js
@@ -27,20 +27,22 @@ function DefaultFilter({
       onChange={(event) => {
         onFilterChanged(columnDef.tableData.id, event.target.value);
       }}
-      inputProps={{ 'aria-label': `filter data by ${columnDef.title}` }}
-      InputProps={
-        hideFilterIcons || columnDef.hideFilterIcon
+      slotProps={{
+        input: hideFilterIcons || columnDef.hideFilterIcon
           ? undefined
           : {
-              startAdornment: (
-                <InputAdornment position="start">
-                  <Tooltip title={_localization.filterTooltip}>
-                    <FilterIcon />
-                  </Tooltip>
-                </InputAdornment>
-              )
-            }
-      }
+            startAdornment: (
+              <InputAdornment position="start">
+                <Tooltip title={_localization.filterTooltip}>
+                  <FilterIcon />
+                </Tooltip>
+              </InputAdornment>
+            )
+          },
+        htmlInput: {
+          'aria-label': `filter data by ${columnDef.title}`
+        }
+      }}
     />
   );
 }

--- a/src/components/MTableToolbar/index.js
+++ b/src/components/MTableToolbar/index.js
@@ -91,7 +91,7 @@ export function MTableToolbar(props) {
           autoFocus={options.searchAutoFocus}
           sx={
             options.searchFieldAlignment === 'left' &&
-            options.showTitle === false
+              options.showTitle === false
               ? undefined
               : styles.searchField
           }
@@ -99,29 +99,31 @@ export function MTableToolbar(props) {
           onChange={(event) => onSearchChange(event.target.value)}
           placeholder={localization.searchPlaceholder}
           variant={options.searchFieldVariant}
-          InputProps={{
-            startAdornment: (
-              <InputAdornment position="start">
-                <Tooltip title={localization.searchTooltip}>
-                  <icons.Search fontSize="small" />
-                </Tooltip>
-              </InputAdornment>
-            ),
-            endAdornment: (
-              <InputAdornment position="end">
-                <IconButton
-                  disabled={!searchText}
-                  onClick={() => onSearchChange('')}
-                  aria-label={localization.clearSearchAriaLabel}
-                >
-                  <icons.ResetSearch fontSize="small" aria-label="clear" />
-                </IconButton>
-              </InputAdornment>
-            ),
-            style: options.searchFieldStyle,
-            inputProps: {
-              'aria-label': localization.searchAriaLabel
-            }
+          slotProps={{
+            input: {
+              startAdornment: (
+                <InputAdornment position="start">
+                  <Tooltip title={localization.searchTooltip}>
+                    <icons.Search fontSize="small" />
+                  </Tooltip>
+                </InputAdornment>
+              ),
+              endAdornment: (
+                <InputAdornment position="end">
+                  <IconButton
+                    disabled={!searchText}
+                    onClick={() => onSearchChange('')}
+                    aria-label={localization.clearSearchAriaLabel}
+                  >
+                    <icons.ResetSearch fontSize="small" aria-label="clear" />
+                  </IconButton>
+                </InputAdornment>
+              ),
+              style: options.searchFieldStyle,
+              inputProps: {
+                'aria-label': localization.searchAriaLabel
+              }
+            },
           }}
         />
       );
@@ -295,8 +297,8 @@ export function MTableToolbar(props) {
         ? localization.nRowsSelected(selectedRows.length)
         : localization.nRowsSelected.replace('{0}', selectedRows.length)
       : options.showTitle
-      ? props.title
-      : null;
+        ? props.title
+        : null;
   return (
     <Toolbar
       ref={props.forwardedRef}
@@ -360,13 +362,13 @@ const styles = {
   highlight: (theme) =>
     theme.palette.mode === 'light'
       ? {
-          color: theme.palette.secondary.main,
-          backgroundColor: lighten(theme.palette.secondary.light, 0.85)
-        }
+        color: theme.palette.secondary.main,
+        backgroundColor: lighten(theme.palette.secondary.light, 0.85)
+      }
       : {
-          color: theme.palette.text.primary,
-          backgroundColor: theme.palette.secondary.dark
-        },
+        color: theme.palette.text.primary,
+        backgroundColor: theme.palette.secondary.dark
+      },
   spacer: {
     flex: '1 1 10%'
   },

--- a/src/components/m-table-edit-field.js
+++ b/src/components/m-table-edit-field.js
@@ -103,19 +103,19 @@ class MTableEditField extends React.Component {
       >
         <DatePicker
           {...this.getProps()}
-          renderInput={(props) => <TextField {...props} />}
           format={dateFormat}
           value={this.props.value || null}
           onChange={this.props.onChange}
-          slotProps={{ actionBar: { actions: ['clear'] } }}
-          InputProps={{
-            style: {
-              fontSize: 13
-            }
-          }}
-          inputProps={{
-            autoFocus: this.props.autoFocus,
-            'aria-label': `${this.props.columnDef.title}: press space to edit`
+          slotProps={{
+            actionBar: { actions: ['clear'] },
+            textField: {
+              InputProps: {
+                style: { fontSize: 13 }
+              },
+              inputProps: {
+                'aria-label': `${props.columnDef.title}: press space to edit`,
+              }
+            },
           }}
         />
       </LocalizationProvider>
@@ -130,19 +130,19 @@ class MTableEditField extends React.Component {
       >
         <TimePicker
           {...this.getProps()}
-          renderInput={(props) => <TextField {...props} />}
           format="HH:mm:ss"
           value={this.props.value || null}
           onChange={this.props.onChange}
-          slotProps={{ actionBar: { actions: ['clear'] } }}
-          InputProps={{
-            style: {
-              fontSize: 13
-            }
-          }}
-          inputProps={{
-            autoFocus: this.props.autoFocus,
-            'aria-label': `${this.props.columnDef.title}: press space to edit`
+          slotProps={{
+            actionBar: { actions: ['clear'] },
+            textField: {
+              InputProps: {
+                style: { fontSize: 13 }
+              },
+              inputProps: {
+                'aria-label': `${props.columnDef.title}: press space to edit`,
+              }
+            },
           }}
         />
       </LocalizationProvider>
@@ -157,19 +157,19 @@ class MTableEditField extends React.Component {
       >
         <DateTimePicker
           {...this.getProps()}
-          renderInput={(props) => <TextField {...props} />}
           format="dd.MM.yyyy HH:mm:ss"
           value={this.props.value || null}
           onChange={this.props.onChange}
-          slotProps={{ actionBar: { actions: ['clear'] } }}
-          InputProps={{
-            style: {
-              fontSize: 13
-            }
-          }}
-          inputProps={{
-            autoFocus: this.props.autoFocus,
-            'aria-label': `${this.props.columnDef.title}: press space to edit`
+          slotProps={{
+            actionBar: { actions: ['clear'] },
+            textField: {
+              InputProps: {
+                style: { fontSize: 13 }
+              },
+              inputProps: {
+                'aria-label': `${props.columnDef.title}: press space to edit`,
+              }
+            },
           }}
         />
       </LocalizationProvider>

--- a/src/components/m-table-edit-field.js
+++ b/src/components/m-table-edit-field.js
@@ -7,7 +7,7 @@ import FormControl from '@mui/material/FormControl';
 import FormHelperText from '@mui/material/FormHelperText';
 import FormGroup from '@mui/material/FormGroup';
 import FormControlLabel from '@mui/material/FormControlLabel';
-import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFnsV3';
+import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import {
   LocalizationProvider,
   TimePicker,
@@ -93,7 +93,7 @@ class MTableEditField extends React.Component {
   renderDateField() {
     const dateFormat =
       this.props.columnDef.dateSetting &&
-      this.props.columnDef.dateSetting.format
+        this.props.columnDef.dateSetting.format
         ? this.props.columnDef.dateSetting.format
         : 'dd.MM.yyyy';
     return (

--- a/src/components/m-table-edit-field.js
+++ b/src/components/m-table-edit-field.js
@@ -77,9 +77,11 @@ class MTableEditField extends React.Component {
                   width: 24,
                   marginLeft: 9
                 }}
-                inputProps={{
-                  autoFocus: this.props.autoFocus,
-                  'aria-label': this.props.columnDef.title
+                slotProps={{
+                  input: {
+                    autoFocus: this.props.autoFocus,
+                    'aria-label': this.props.columnDef.title
+                  }
                 }}
               />
             }
@@ -113,6 +115,7 @@ class MTableEditField extends React.Component {
                 style: { fontSize: 13 }
               },
               inputProps: {
+                autoFocus: this.props.autoFocus,
                 'aria-label': `${this.props.columnDef.title}: press space to edit`,
               }
             },
@@ -140,6 +143,7 @@ class MTableEditField extends React.Component {
                 style: { fontSize: 13 }
               },
               inputProps: {
+                autoFocus: this.props.autoFocus,
                 'aria-label': `${this.props.columnDef.title}: press space to edit`,
               }
             },
@@ -167,6 +171,7 @@ class MTableEditField extends React.Component {
                 style: { fontSize: 13 }
               },
               inputProps: {
+                autoFocus: this.props.autoFocus,
                 'aria-label': `${this.props.columnDef.title}: press space to edit`,
               }
             },

--- a/src/components/m-table-edit-field.js
+++ b/src/components/m-table-edit-field.js
@@ -107,7 +107,7 @@ class MTableEditField extends React.Component {
           format={dateFormat}
           value={this.props.value || null}
           onChange={this.props.onChange}
-          clearable
+          slotProps={{ actionBar: { actions: ['clear'] } }}
           InputProps={{
             style: {
               fontSize: 13
@@ -134,7 +134,7 @@ class MTableEditField extends React.Component {
           format="HH:mm:ss"
           value={this.props.value || null}
           onChange={this.props.onChange}
-          clearable
+          slotProps={{ actionBar: { actions: ['clear'] } }}
           InputProps={{
             style: {
               fontSize: 13
@@ -161,7 +161,7 @@ class MTableEditField extends React.Component {
           format="dd.MM.yyyy HH:mm:ss"
           value={this.props.value || null}
           onChange={this.props.onChange}
-          clearable
+          slotProps={{ actionBar: { actions: ['clear'] } }}
           InputProps={{
             style: {
               fontSize: 13

--- a/src/components/m-table-edit-field.js
+++ b/src/components/m-table-edit-field.js
@@ -194,19 +194,21 @@ class MTableEditField extends React.Component {
               : event.target.value
           )
         }
-        InputProps={{
-          style: {
-            minWidth: 50,
-            fontSize: 13
+        slotProps={{
+          input: {
+            style: {
+              minWidth: 50,
+              fontSize: 13
+            }
+          },
+          htmlInput: {
+            autoFocus: this.props.autoFocus,
+            'aria-label': this.props.columnDef.title,
+            style:
+              this.props.columnDef.type === 'numeric'
+                ? { textAlign: 'right' }
+                : {}
           }
-        }}
-        inputProps={{
-          autoFocus: this.props.autoFocus,
-          'aria-label': this.props.columnDef.title,
-          style:
-            this.props.columnDef.type === 'numeric'
-              ? { textAlign: 'right' }
-              : {}
         }}
       />
     );
@@ -229,16 +231,18 @@ class MTableEditField extends React.Component {
           }
           return this.props.onChange(value);
         }}
-        InputProps={{
-          style: {
-            fontSize: 13,
-            textAlign: 'right'
+        slotProps={{
+          input: {
+            style: {
+              fontSize: 13,
+              textAlign: 'right'
+            }
+          },
+          htmlInput: {
+            autoFocus: this.props.autoFocus,
+            'aria-label': this.props.columnDef.title,
+            style: { textAlign: 'right' }
           }
-        }}
-        inputProps={{
-          autoFocus: this.props.autoFocus,
-          'aria-label': this.props.columnDef.title,
-          style: { textAlign: 'right' }
         }}
         onKeyDown={this.props.onKeyDown}
       />

--- a/src/components/m-table-edit-field.js
+++ b/src/components/m-table-edit-field.js
@@ -113,7 +113,7 @@ class MTableEditField extends React.Component {
                 style: { fontSize: 13 }
               },
               inputProps: {
-                'aria-label': `${props.columnDef.title}: press space to edit`,
+                'aria-label': `${this.props.columnDef.title}: press space to edit`,
               }
             },
           }}
@@ -140,7 +140,7 @@ class MTableEditField extends React.Component {
                 style: { fontSize: 13 }
               },
               inputProps: {
-                'aria-label': `${props.columnDef.title}: press space to edit`,
+                'aria-label': `${this.props.columnDef.title}: press space to edit`,
               }
             },
           }}
@@ -167,7 +167,7 @@ class MTableEditField extends React.Component {
                 style: { fontSize: 13 }
               },
               inputProps: {
-                'aria-label': `${props.columnDef.title}: press space to edit`,
+                'aria-label': `${this.props.columnDef.title}: press space to edit`,
               }
             },
           }}


### PR DESCRIPTION
This pull request updates the way date and time pickers are implemented throughout the codebase to use the latest `@mui/x-date-pickers` adapters, removing legacy dependencies and improving consistency. The changes also update related imports and usage patterns to align with current best practices.

**Date and Time Picker Migration:**

* Replaced all usage of `@date-io/date-fns` and `@mui/x-date-pickers/AdapterDateFnsV3` with `@mui/x-date-pickers/AdapterDateFns` in components handling date and time fields, such as `DateField`, `DateTimeField`, `TimeField`, and `DateFilter` (`src/components/MTableEditField/DateField.js`, `src/components/MTableEditField/DateTimeField.js`, `src/components/MTableEditField/TimeField.js`, `src/components/MTableFilterRow/DateFilter.js`, `src/components/m-table-edit-field.js`). [[1]](diffhunk://#diff-7a36ed070e9cb181a89484ace5b647f772e913e29a81cc2470b6dd743f8402e4L2-R2) [[2]](diffhunk://#diff-0a7abf3266018048493254076db4730a24010416b18a3c48335be61f1839095bL2-R16) [[3]](diffhunk://#diff-f2a94aa346eb43e8ebc323967f58388de851a4d43e501f18863817e1ceeb0bccL2-R16) [[4]](diffhunk://#diff-e10a7a66cf70f20f891abc88ab7aabc1d155d8d91b424974f5955d5d18c74197L2-R2) [[5]](diffhunk://#diff-51de0d2b50cbb3f214db5c76aca37ecb44c06f9678050918d7e3b9d7d2a50a0eL10-R10)

* Updated the implementation of `DateTimeField` and `TimeField` to use the `renderInput` prop for custom text field rendering and adjusted the `clearable` prop usage for compatibility with the new adapter. [[1]](diffhunk://#diff-0a7abf3266018048493254076db4730a24010416b18a3c48335be61f1839095bL2-R16) [[2]](diffhunk://#diff-f2a94aa346eb43e8ebc323967f58388de851a4d43e501f18863817e1ceeb0bccL2-R16)

**Dependency Cleanup:**

* Removed `@date-io/core` and `@date-io/date-fns` from `package.json` as they are no longer needed after migrating to the new adapter.