### PR TITLE
feat(CON-0000): allow configuring filter control size

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,26 @@ export default function UsersTable() {
 
 The upstream [documentation](https://material-table-core.github.io/docs) and [demos](https://material-table-core.github.io/demos/) remain the primary references for the shared API. Fork-specific behavior should be documented in this README or the release notes.
 
+### Filter control size
+
+Use `filterControlSize` to render the controls in the filter row with MUI's
+`small` or `medium` size. The default is `medium`.
+
+```jsx
+<MaterialTable
+  columns={columns}
+  data={data}
+  options={{
+    filtering: true,
+    filterControlSize: 'small'
+  }}
+/>
+```
+
+The configured value applies to the built-in text, lookup, date, time, and
+boolean filters. Custom `filterComponent` implementations receive it through
+their `size` prop.
+
 ## Package outputs
 
 The published package exposes:

--- a/__tests__/filterControlSize.test.js
+++ b/__tests__/filterControlSize.test.js
@@ -1,0 +1,58 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import MaterialTable from '../src';
+
+describe('filterControlSize', () => {
+  test('applies the configured size to built-in filter controls', () => {
+    render(
+      <MaterialTable
+        columns={[{ title: 'Name', field: 'name' }]}
+        data={[]}
+        options={{
+          filtering: true,
+          filterControlSize: 'small',
+          paging: false,
+          search: false,
+          toolbar: false
+        }}
+      />
+    );
+
+    expect(
+      screen.getByLabelText('filter data by Name').closest('.MuiInputBase-root')
+    ).toHaveClass('MuiInputBase-sizeSmall');
+  });
+
+  test('passes the configured size to custom filter components', () => {
+    const CustomFilter = ({ size }) => (
+      <input data-testid="custom-filter" data-size={size} />
+    );
+
+    render(
+      <MaterialTable
+        columns={[
+          {
+            title: 'Name',
+            field: 'name',
+            filterComponent: CustomFilter
+          }
+        ]}
+        data={[]}
+        options={{
+          filtering: true,
+          filterControlSize: 'small',
+          paging: false,
+          search: false,
+          toolbar: false
+        }}
+      />
+    );
+
+    expect(screen.getByTestId('custom-filter')).toHaveAttribute(
+      'data-size',
+      'small'
+    );
+  });
+});

--- a/src/components/MTableFilterRow/BooleanFilter.js
+++ b/src/components/MTableFilterRow/BooleanFilter.js
@@ -1,10 +1,11 @@
 import React from 'react';
 import { Checkbox } from '@mui/material';
 
-function BooleanFilter({ forwardedRef, columnDef, onFilterChanged }) {
+function BooleanFilter({ forwardedRef, columnDef, onFilterChanged, size }) {
   return (
     <Checkbox
       ref={forwardedRef}
+      size={size}
       slotProps={{
         input: { 'aria-label': `Filter of ${columnDef.title}` }
       }}

--- a/src/components/MTableFilterRow/DateFilter.js
+++ b/src/components/MTableFilterRow/DateFilter.js
@@ -12,7 +12,8 @@ function DateFilter({
   columnDef,
   onFilterChanged,
   localization,
-  forwardedRef
+  forwardedRef,
+  size
 }) {
   const onDateInputChange = (date) =>
     onFilterChanged(columnDef.tableData.id, date);
@@ -21,7 +22,10 @@ function DateFilter({
     value: columnDef.tableData.filterValue || null,
     onChange: onDateInputChange,
     placeholder: getLocalizedFilterPlaceHolder(columnDef, localization),
-    slotProps: { actionBar: { actions: ['clear'] } }
+    slotProps: {
+      actionBar: { actions: ['clear'] },
+      textField: { size }
+    }
   };
   let dateInputElement = null;
   if (columnDef.type === 'date') {

--- a/src/components/MTableFilterRow/DefaultFilter.js
+++ b/src/components/MTableFilterRow/DefaultFilter.js
@@ -8,7 +8,8 @@ function DefaultFilter({
   localization,
   hideFilterIcons,
   onFilterChanged,
-  forwardedRef
+  forwardedRef,
+  size
 }) {
   const _localization = getLocalizationData(localization);
   const FilterIcon = icons.Filter;
@@ -16,6 +17,7 @@ function DefaultFilter({
   return (
     <TextField
       ref={forwardedRef}
+      size={size}
       style={
         columnDef.type === 'numeric'
           ? { float: columnDef.align ?? 'right' }

--- a/src/components/MTableFilterRow/Filter.js
+++ b/src/components/MTableFilterRow/Filter.js
@@ -1,10 +1,11 @@
 import React, { createElement } from 'react';
 
-function Filter({ columnDef, onFilterChanged, forwardedRef }) {
+function Filter({ columnDef, onFilterChanged, forwardedRef, size }) {
   return createElement(columnDef.filterComponent, {
     columnDef,
     onFilterChanged,
-    forwardedRef
+    forwardedRef,
+    size
   });
 }
 

--- a/src/components/MTableFilterRow/LookupFilter.js
+++ b/src/components/MTableFilterRow/LookupFilter.js
@@ -27,7 +27,8 @@ function LookupFilter({
   columnDef,
   onFilterChanged,
   localization,
-  forwardedRef
+  forwardedRef,
+  size
 }) {
   const [selectedFilter, setSelectedFilter] = useState(
     columnDef.tableData.filterValue || []
@@ -38,7 +39,7 @@ function LookupFilter({
   }, [columnDef.tableData.filterValue]);
 
   return (
-    <FormControl style={{ width: '100%' }} ref={forwardedRef}>
+    <FormControl size={size} style={{ width: '100%' }} ref={forwardedRef}>
       <InputLabel
         htmlFor={'select-multiple-checkbox' + columnDef.tableData.id}
         style={{ marginTop: -16 }}
@@ -46,6 +47,7 @@ function LookupFilter({
         {getLocalizedFilterPlaceHolder(columnDef, localization)}
       </InputLabel>
       <Select
+        size={size}
         multiple
         value={selectedFilter}
         onClose={() => {
@@ -68,7 +70,10 @@ function LookupFilter({
       >
         {Object.keys(columnDef.lookup).map((key) => (
           <MenuItem key={key} value={key}>
-            <Checkbox checked={selectedFilter.indexOf(key.toString()) > -1} />
+            <Checkbox
+              size={size}
+              checked={selectedFilter.indexOf(key.toString()) > -1}
+            />
             <ListItemText primary={columnDef.lookup[key]} />
           </MenuItem>
         ))}

--- a/src/components/MTableFilterRow/index.js
+++ b/src/components/MTableFilterRow/index.js
@@ -26,15 +26,45 @@ export function MTableFilterRow({
     }
     if (columnDef.field || columnDef.customFilterAndSearch) {
       if (columnDef.filterComponent) {
-        return <Filter columnDef={columnDef} {...props} />;
+        return (
+          <Filter
+            columnDef={columnDef}
+            {...props}
+            size={options.filterControlSize}
+          />
+        );
       } else if (columnDef.lookup) {
-        return <LookupFilter columnDef={columnDef} {...props} />;
+        return (
+          <LookupFilter
+            columnDef={columnDef}
+            {...props}
+            size={options.filterControlSize}
+          />
+        );
       } else if (columnDef.type === 'boolean') {
-        return <BooleanFilter columnDef={columnDef} {...props} />;
+        return (
+          <BooleanFilter
+            columnDef={columnDef}
+            {...props}
+            size={options.filterControlSize}
+          />
+        );
       } else if (['date', 'datetime', 'time'].includes(columnDef.type)) {
-        return <DateFilter columnDef={columnDef} {...props} />;
+        return (
+          <DateFilter
+            columnDef={columnDef}
+            {...props}
+            size={options.filterControlSize}
+          />
+        );
       } else {
-        return <DefaultFilter columnDef={columnDef} {...props} />;
+        return (
+          <DefaultFilter
+            columnDef={columnDef}
+            {...props}
+            size={options.filterControlSize}
+          />
+        );
       }
     }
   }

--- a/src/defaults/props.options.js
+++ b/src/defaults/props.options.js
@@ -14,6 +14,7 @@ export default {
   exportAllData: false,
   exportMenu: [],
   filtering: false,
+  filterControlSize: 'medium',
   groupTitle: false,
   header: true,
   headerSelectionProps: {},

--- a/src/prop-types.js
+++ b/src/prop-types.js
@@ -346,6 +346,7 @@ export const propTypes = {
     ),
     filtering: PropTypes.bool,
     filterCellStyle: PropTypes.object,
+    filterControlSize: PropTypes.oneOf(['small', 'medium']),
     filterRowStyle: PropTypes.object,
     header: PropTypes.bool,
     headerSelectionProps: PropTypes.object,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -246,6 +246,7 @@ export interface Column<RowData extends object> {
     columnDef: Column<RowData>;
     // The columnId can be extracted from columnDef.tableData.id
     onFilterChanged: (columnId: number, value: any) => void;
+    size?: 'small' | 'medium';
   }) => React.ReactNode;
   filterPlaceholder?: string;
   filterCellStyle?: React.CSSProperties;
@@ -404,6 +405,7 @@ export interface Options<RowData extends object> {
   }[];
   filtering?: boolean;
   filterCellStyle?: React.CSSProperties;
+  filterControlSize?: 'small' | 'medium';
   filterRowStyle?: React.CSSProperties;
   fixedColumns?: { left?: number; right?: number };
   groupRowSeparator?: string;


### PR DESCRIPTION
## Summary

- add `options.filterControlSize` with `small` and `medium` values
- apply the configured size to text, lookup, date/time, boolean, and custom filters
- preserve `medium` as the default for backward compatibility
- document the option and add integration coverage

## Why

Consumers need to render compact filter rows using MUI's native sizing API without replacing `MTableFilterRow` or overriding component styles.

## Validation

- `npm run lint`
- `npm test -- --runInBand` (15 suites passed, 56 tests passed)
- `npm run test:build`
- `npm run build`